### PR TITLE
Correction for the ActiveSupport String#camelize method

### DIFF
--- a/lib/railroady/app_diagram.rb
+++ b/lib/railroady/app_diagram.rb
@@ -8,11 +8,11 @@ require 'railroady/diagram_graph'
 
 # camelize and constantize methods brought over from active_support
 class String
-  def camelize(first_letter_in_uppercase = true)
-    if first_letter_in_uppercase
+  def camelize(first_letter = :upper)
+    if first_letter == :upper
       self.to_s.gsub(/\/(.?)/) { "::" + $1.upcase }.gsub(/(^|_)(.)/) { $2.upcase }
     else
-      self.first + self.camelize[1..-1]
+      self.to_s[0].chr.downcase + self.camelize[1..-1]
     end
   end
   def constantize

--- a/rspec/core_ext_spec.rb
+++ b/rspec/core_ext_spec.rb
@@ -1,0 +1,13 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+describe String do
+  describe '#camelize' do
+    it "should upper-camelcase a lower case and underscored word" do
+      'lower_case_and_underscored_word'.camelize.should == 'LowerCaseAndUnderscoredWord'
+    end
+
+    it "should lower-camelcase a lower case and underscored word when the :lower parameter is passed" do
+      'lower_case_and_underscored_word'.camelize(:lower).should == 'lowerCaseAndUnderscoredWord'
+    end
+  end
+end


### PR DESCRIPTION
Hello! Thanks for your work on Railroady, it's been terrific for us. I wanted to submit a bugfix for the gem.

I updated the String#camelize code pulled from ActiveSupport and corrected the method arguments so that the :upper and :lower arguments work properly. To verify proper function, I added two rspec tests, using the syntax from Rails' documentation.

If it would help for me to explain further, please don't hesitate to let me know!
