### PR TITLE
rake tasks in directories with spaces.

### DIFF
--- a/tasks/railroady.rake
+++ b/tasks/railroady.rake
@@ -9,7 +9,7 @@
  
 # Returns an absolute path for the following file.
 def full_path(name = 'test.txt')
-  f = File.join(Rails.root.to_s, 'doc', name)
+  f = File.join(Rails.root.to_s.gsub(' ', '\ '), 'doc', name)
   f.to_s
 end
   


### PR DESCRIPTION
The rake tasks were not working if the rails project was in a directory that contained spaces.
