### PR TITLE
Fix for rooted associtation classes

### DIFF
--- a/lib/railroady/models_diagram.rb
+++ b/lib/railroady/models_diagram.rb
@@ -129,11 +129,12 @@ class ModelsDiagram < AppDiagram
       assoc_name = assoc.name.to_s
     end 
 
-		# Patch from "alpack" to support classes in a non-root module namespace. See: http://disq.us/yxl1v
-		if class_name.include?("::") && !assoc_class_name.include?("::")
-		     assoc_class_name = class_name.split("::")[0..-2].push(assoc_class_name).join("::")
-		end
-		
+    # Patch from "alpack" to support classes in a non-root module namespace. See: http://disq.us/yxl1v
+    if class_name.include?("::") && !assoc_class_name.include?("::")
+      assoc_class_name = class_name.split("::")[0..-2].push(assoc_class_name).join("::")
+    end
+    assoc_class_name.gsub!(%r{^::}, '')
+
     if ['has_one', 'belongs_to'].include? assoc.macro.to_s
       assoc_type = 'one-one'
     elsif assoc.macro.to_s == 'has_many' && (! assoc.options[:through])


### PR DESCRIPTION
In a particularly large Rails project w/ models defined within a module namespace, with Ruby Enterprise I sometimes have to qualify association class names with a leading :: to get Ruby to find them. With this patch (which included a reformatting of the code above it), those names with leading :: get the :: stripped so that their associations can be properly included into the classes that can be found without the ::. Otherwise, you can get duplicate instances of the models on the graph, one with :: and one without.
