### PR TITLE
disable_stdout didn't work with mingw setup

### DIFF
--- a/lib/railroady/app_diagram.rb
+++ b/lib/railroady/app_diagram.rb
@@ -66,7 +66,7 @@ class AppDiagram
   # Prevents Rails application from writing to STDOUT
   def disable_stdout
     @old_stdout = STDOUT.dup
-    STDOUT.reopen(::RUBY_PLATFORM =~ /mswin/ ? "NUL" : "/dev/null")
+    STDOUT.reopen(::RUBY_PLATFORM.downcase =~ /(mswin|mingw)/ ? "NUL" : "/dev/null")
   end
 
   # Restore STDOUT  


### PR DESCRIPTION
small change, but directing STDOUT to /dev/null on windows made it fail,
so i included a check for mingw.
