### PR TITLE
do not add through associations if transitive option is turned off

### DIFF
--- a/lib/railroady/models_diagram.rb
+++ b/lib/railroady/models_diagram.rb
@@ -250,6 +250,7 @@ class ModelsDiagram < AppDiagram
     else # habtm or has_many, :through
       # Add FAKE associations too in order to understand mistakes
       return if @habtm.include? [assoc_class_name, class_name, assoc_name]
+      return if assoc.options[:through] && ! @options.transitive
       assoc_type = 'many-many'
       @habtm << [class_name, assoc_class_name, assoc_name]
     end


### PR DESCRIPTION
Hi,

Thanks for improving railroad and making it great.

docs:
    -t, --transitive                 Include transitive associations
                                     (through inheritance)

I read: don't show :through associations unless -t flag is present.
Unfortunately, through associations are always displayed

Here is a patch to implement it.

If you have a different approach, please let me know and I'll fix.

Thanks,
Keenan
