### PR TITLE
use sed to strip ansi codes from railroady output

### DIFF
--- a/tasks/railroady.rake
+++ b/tasks/railroady.rake
@@ -29,20 +29,22 @@ namespace :diagram do
   @CONTROLLERS_ALL = RailRoady::RakeHelpers.full_path("controllers_complete.#{RailRoady::RakeHelpers.format}").freeze
   @CONTROLLERS_BRIEF = RailRoady::RakeHelpers.full_path("controllers_brief.#{RailRoady::RakeHelpers.format}").freeze
 
+  @SED = 'sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"'
+
   namespace :models do
 
     desc 'Generates an class diagram for all models.'
     task :complete do
       f = @MODELS_ALL
       puts "Generating #{f}"
-      sh "railroady -ilamM | dot -T#{RailRoady::RakeHelpers.format} > #{f}"
+      sh "railroady -ilamM | #{@SED} | dot -T#{RailRoady::RakeHelpers.format} > #{f}"
     end
 
     desc 'Generates an abbreviated class diagram for all models.'
     task :brief do
       f = @MODELS_BRIEF
       puts "Generating #{f}"
-      sh "railroady -bilamM | dot -T#{RailRoady::RakeHelpers.format} > #{f}"
+      sh "railroady -bilamM | #{@SED} | dot -T#{RailRoady::RakeHelpers.format} > #{f}"
     end
 
   end
@@ -53,14 +55,14 @@ namespace :diagram do
     task :complete do
       f = @CONTROLLERS_ALL
       puts "Generating #{f}"
-      sh "railroady -ilC | neato -T#{RailRoady::RakeHelpers.format} > #{f}"
+      sh "railroady -ilC | #{@SED} | neato -T#{RailRoady::RakeHelpers.format} > #{f}"
     end
 
     desc 'Generates an abbreviated class diagram for all controllers.'
     task :brief do
       f = @CONTROLLERS_BRIEF
       puts "Generating #{f}"
-      sh "railroady -bilC | neato -T#{RailRoady::RakeHelpers.format} > #{f}"
+      sh "railroady -bilC | #{@SED} | neato -T#{RailRoady::RakeHelpers.format} > #{f}"
     end
 
   end


### PR DESCRIPTION
For some odd reason railroady adds an ansi colour code (specfifically [[0m) at the end of its output causing dot and neato to choke. 

This is not the clever way of solving the problem, but it works - basically sed is invoked on the output to strip any ansi codes before passing on the data to dot/neato.

If I don't use this, railroady will crash with:

```
Error: <stdin>:0: syntax error near line 0
context:  >>> Warning: <stdin>:0: ambiguous "0m" splits into two names: "0" and "m"
```

FYI, this works with GNU sed version 4.2.1.
