### PR TITLE
Railroady does not work with Sinatra/Padrino

### DIFF
--- a/lib/railroady/app_diagram.rb
+++ b/lib/railroady/app_diagram.rb
@@ -52,7 +52,7 @@ class AppDiagram
     STDERR.print "Loading application environment\n" if @options.verbose
     begin
       disable_stdout
-      l = File.join(Dir.pwd.to_s, 'config/environment')
+      l = File.join(Dir.pwd.to_s, @options.config_file)
       require l
       enable_stdout
     rescue LoadError

--- a/lib/railroady/options_struct.rb
+++ b/lib/railroady/options_struct.rb
@@ -34,6 +34,7 @@ class OptionsStruct < OpenStruct
                      :verbose => false,
                      :xmi => false,
                      :command => '',
+                     :config_file => 'config/environment',
                      :app_name => 'railroady', :app_human_name => 'Railroady', :app_version =>'', :copyright =>'' }
     super(init_options.merge(args))
   end # initialize
@@ -132,6 +133,11 @@ class OptionsStruct < OpenStruct
         exit
       end
       opts.separator ""
+      opts.on("-c", "--config FILE", "File to load environment (defaults to config/environment)") do |c|
+        if c && c != ''
+          self.config_file = c
+        end
+      end
       opts.separator "Commands (you must supply one of these):"
       opts.on("-M", "--models", "Generate models diagram") do |c|
         if self.command != ''


### PR DESCRIPTION
Railroady works only with rails. It does not work with Sinatra/Padrino where environment file is config/boot.rb instead of config/environment.rb.

I've made config file location as a command line option to make it work in Sinatra/Padrino apps
