### PR TITLE
fix_default_folder_creation

### DIFF
--- a/tasks/railroady.rake
+++ b/tasks/railroady.rake
@@ -1,11 +1,11 @@
 # This suite of tasks generate graphical diagrams via code analysis.
 # A UNIX-like environment is required as well as:
-# 
+#
 # * The railroady gem. (http://github.com/preston/railroady)
 # * The graphviz package which includes the `dot` and `neato` command-line utilities. MacPorts users can install in via `sudo port install graphviz`.
 # * The `sed` command-line utility, which should already be available on all sane UNIX systems.
 #
-# Author: Preston Lee, http://railroady.prestonlee.com 
+# Author: Preston Lee, http://railroady.prestonlee.com
 
 # wrap helper methods so they don't conflict w/ methods on Object
 
@@ -40,13 +40,18 @@ end
 
 namespace :diagram do
 
-  Dir.mkdir('doc') unless File.exists?('doc')
+  @MODELS_ALL         = RailRoady::RakeHelpers.full_path("models_complete.#{RailRoady::RakeHelpers.format}").freeze
+  @MODELS_BRIEF       = RailRoady::RakeHelpers.full_path("models_brief.#{RailRoady::RakeHelpers.format}").freeze
+  @CONTROLLERS_ALL    = RailRoady::RakeHelpers.full_path("controllers_complete.#{RailRoady::RakeHelpers.format}").freeze
+  @CONTROLLERS_BRIEF  = RailRoady::RakeHelpers.full_path("controllers_brief.#{RailRoady::RakeHelpers.format}").freeze
+  @SED                = RailRoady::RakeHelpers.sed
 
-  @MODELS_ALL = RailRoady::RakeHelpers.full_path("models_complete.#{RailRoady::RakeHelpers.format}").freeze
-  @MODELS_BRIEF = RailRoady::RakeHelpers.full_path("models_brief.#{RailRoady::RakeHelpers.format}").freeze
-  @CONTROLLERS_ALL = RailRoady::RakeHelpers.full_path("controllers_complete.#{RailRoady::RakeHelpers.format}").freeze
-  @CONTROLLERS_BRIEF = RailRoady::RakeHelpers.full_path("controllers_brief.#{RailRoady::RakeHelpers.format}").freeze
-  @SED = RailRoady::RakeHelpers.sed
+  namespace :setup do
+    desc 'Perform any setup needed for the gem'
+    task :create_new_doc_folder_if_needed do
+      Dir.mkdir('doc') unless File.exists?('doc')
+    end
+  end
 
   namespace :models do
 
@@ -85,6 +90,9 @@ namespace :diagram do
   end
 
   desc 'Generates all class diagrams.'
-  task :all => ['diagram:models:complete', 'diagram:models:brief', 'diagram:controllers:complete', 'diagram:controllers:brief']
-
+  task all: ['diagram:setup:create_new_doc_folder_if_needed',
+             'diagram:models:complete',
+             'diagram:models:brief',
+             'diagram:controllers:complete',
+             'diagram:controllers:brief']
 end


### PR DESCRIPTION
Hi,

I was using your gem and I noticed that I had to manually create the doc folder or else I would receive the following error.
- Invoke diagram:all (first_time)
  *\* Invoke diagram:models:complete (first_time)
  *\* Execute diagram:models:complete
  Generating /home/BobJones/Project/doc/models_complete.svg
  railroady -ilamM | sed -r 's/\x1B[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' | dot -Tsvg > /home/rudik/Projects/Battleshipz/doc/models_complete.svg
  sh: 1: cannot create/home/BobJones/Project/doc/models_complete.svg: Directory nonexistent

I started poking around and I noticed that your code to handle the folder setup was not in a task. So I added new namespace called setup and a task called create_new_doc_folder_if_needed  and put your existing code in to that class. I then added the create_new_doc_folder_if_needed task to the "All" task and that seemed to fix my problem.

(Apologies for the commits removing trailing white spaces, those edits were made by my OCD and I take no responsibility for them.)
