### PR TITLE
Generate both model or both controller diagrams

### DIFF
--- a/tasks/railroady.rake
+++ b/tasks/railroady.rake
@@ -50,6 +50,9 @@ namespace :diagram do
 
   namespace :models do
 
+    desc 'Generated brief and complete class diagrams for all models.'
+    task :all => ['diagram:models:complete', 'diagram:models:brief']
+
     desc 'Generates an class diagram for all models.'
     task :complete do
       f = @MODELS_ALL
@@ -67,6 +70,9 @@ namespace :diagram do
   end
 
   namespace :controllers do
+    
+    desc 'Generated brief and complete class diagrams for all controllers.'
+    task :all => ['diagram:controllers:complete', 'diagram:controllers:brief']
 
     desc 'Generates an class diagram for all controllers.'
     task :complete do


### PR DESCRIPTION
This pull request adds rake tasks to generate either all model diagrams (complete and brief) or all controller diagrams (complete and brief).

This is great for guard watchers, for instance, that regenerate both controller diagrams when a controller changes (or alternately for model changes.)
