### PR TITLE
ml - convert ModuleName::ClassName to module_name__class_name

### DIFF
--- a/lib/railroady/aasm_diagram.rb
+++ b/lib/railroady/aasm_diagram.rb
@@ -60,6 +60,7 @@ class AasmDiagram < AppDiagram
   end # process_class
 
   def process_acts_as_state_machine_class(current_class)
+    dot_name = DiagramGraph.dotify(current_class.name.downcase)
     node_attribs = []
     node_type = 'aasm'
     
@@ -67,7 +68,7 @@ class AasmDiagram < AppDiagram
     current_class.states.each do |state_name|
       state = current_class.read_inheritable_attribute(:states)[state_name]
       node_shape = (current_class.initial_state === state_name) ? ", peripheries = 2" : ""
-      node_attribs << "#{current_class.name.downcase}_#{state_name} [label=#{state_name} #{node_shape}];"
+      node_attribs << "#{dot_name}_#{state_name} [label=#{state_name} #{node_shape}];"
     end
     @graph.add_node [node_type, current_class.name, node_attribs]
 
@@ -75,8 +76,8 @@ class AasmDiagram < AppDiagram
       event.each do |transition|
         @graph.add_edge [
                          'event',
-                         current_class.name.downcase + "_" + transition.from.to_s,
-                         current_class.name.downcase + "_" + transition.to.to_s,
+                         dot_name + "_" + transition.from.to_s,
+                         dot_name + "_" + transition.to.to_s,
                          event_name.to_s
                         ]
       end
@@ -84,13 +85,14 @@ class AasmDiagram < AppDiagram
   end
 
   def process_aasm_class(current_class)
+    dot_name = DiagramGraph.dotify(current_class.name.downcase)
     node_attribs = []
     node_type = 'aasm'
 
     STDERR.print "\t\tprocessing as aasm\n" if @options.verbose
     current_class.aasm_states.each do |state|
       node_shape = (current_class.aasm_initial_state === state.name) ? ", peripheries = 2" : ""
-      node_attribs << "#{current_class.name.downcase}_#{state.name} [label=#{state.name} #{node_shape}];"
+      node_attribs << "#{dot_name}_#{state.name} [label=#{state.name} #{node_shape}];"
     end
     @graph.add_node [node_type, current_class.name, node_attribs]
 
@@ -98,8 +100,8 @@ class AasmDiagram < AppDiagram
       event.all_transitions.each do |transition|
         @graph.add_edge [
                          'event',
-                         current_class.name.downcase + "_" + transition.from.to_s,
-                         current_class.name.downcase + "_" + transition.to.to_s,
+                         dot_name + "_" + transition.from.to_s,
+                         dot_name + "_" + transition.to.to_s,
                          event_name.to_s
                         ]
       end

--- a/lib/railroady/diagram_graph.rb
+++ b/lib/railroady/diagram_graph.rb
@@ -51,6 +51,11 @@ class DiagramGraph
      return ""
   end
 
+  # Convert to a valid DOT identifier
+  def self.dotify(class_name)
+    class_name.gsub(/::/, '__').downcase
+  end
+
   private
 
   # Build DOT diagram header
@@ -105,7 +110,7 @@ class DiagramGraph
            options = 'shape=box, style=dotted, label="' + name + '"'
       when 'aasm'
            # Return subgraph format
-           return "subgraph cluster_#{name.downcase} {\n\tlabel = #{quote(name)}\n\t#{attributes.join("\n  ")}}"
+           return "subgraph cluster_#{DiagramGraph.dotify(name)} {\n\tlabel = #{quote(name)}\n\t#{attributes.join("\n  ")}}"
     end # case
     return "\t#{quote(name)} [#{options}]\n"
   end # dot_node


### PR DESCRIPTION
This fixes a problem I had with a namespaced model causing invalid DOT identifiers.
Not sure if this is the best fix, though.