### PR TITLE
Fix deprecations from aasm Gem

### DIFF
--- a/lib/railroady/aasm_diagram.rb
+++ b/lib/railroady/aasm_diagram.rb
@@ -63,7 +63,7 @@ class AasmDiagram < AppDiagram
   def process_acts_as_state_machine_class(current_class)
     node_attribs = []
     node_type = 'aasm'
-    
+
     STDERR.print "\t\tprocessing as acts_as_state_machine\n" if @options.verbose
     current_class.states.each do |state_name|
       state = current_class.read_inheritable_attribute(:states)[state_name]
@@ -89,14 +89,14 @@ class AasmDiagram < AppDiagram
     node_type = 'aasm'
 
     STDERR.print "\t\tprocessing as aasm\n" if @options.verbose
-    current_class.aasm_states.each do |state|
-      node_shape = (current_class.aasm_initial_state === state.name) ? ", peripheries = 2" : ""
+    current_class.aasm.states.each do |state|
+      node_shape = (current_class.aasm.initial_state === state.name) ? ", peripheries = 2" : ""
       node_attribs << "#{current_class.name.downcase}_#{state.name} [label=#{state.name} #{node_shape}];"
     end
     @graph.add_node [node_type, current_class.name, node_attribs]
 
-    current_class.aasm_events.each do |event_name, event|
-      event.all_transitions.each do |transition|
+    current_class.aasm.events.each do |event_name, event|
+      event.transitions.each do |transition|
         @graph.add_edge [
                          'event',
                          current_class.name.downcase + "_" + transition.from.to_s,


### PR DESCRIPTION
aasm is throwing these warnings:

```
.aasm_events is deprecated and will be removed in version 4.0.0; please use .aasm.events instead!
.aasm_initial_state is deprecated and will be removed in version 4.0.0; please use .aasm.initial_state instead!
.aasm_states is deprecated and will be removed in version 4.0.0; please use .aasm.states instead!
Event#all_transitions is deprecated and will be removed in version 4.0.0; please use Event#transitions instead!
```

so basically,

``` diff
-    current_class.aasm_events
+    current_class.aasm.events
```

``` diff
-      current_class.aasm_initial_state
+     current_class.aasm.initial_state
```

``` diff
-    current_class.aasm_states
+    current_class.aasm.states
```

``` diff
-      event.all_transitions
+      event.transitions
```
