### PR TITLE
Visualize belongs_to association following official Rails doc

### DIFF
--- a/lib/railroady/diagram_graph.rb
+++ b/lib/railroady/diagram_graph.rb
@@ -123,6 +123,9 @@ class DiagramGraph
            options += "arrowtail=odot, arrowhead=crow" + suffix
       when 'many-many'
            options += "arrowtail=crow, arrowhead=crow" + suffix
+      when 'belongs-to'
+           # following http://guides.rubyonrails.org/association_basics.html#the-belongs-to-association
+           options += "arrowtail=none, arrowhead=normal" + suffix
       when 'is-a'
            options += 'arrowhead="none", arrowtail="onormal"'
       when 'event'

--- a/lib/railroady/models_diagram.rb
+++ b/lib/railroady/models_diagram.rb
@@ -300,6 +300,8 @@ class ModelsDiagram < AppDiagram
     elsif macro == 'has_many' && (!assoc.options[:through]) ||
           %w[references_many embeds_many].include?(macro)
       assoc_type = 'one-many'
+    elsif macro == 'belongs_to'
+      assoc_type = 'belongs-to'
     else # habtm or has_many, :through
       # Add FAKE associations too in order to understand mistakes
       return if @habtm.include? [assoc_class_name, class_name, assoc_name]


### PR DESCRIPTION
Activated with existing switch --show-belongs_to e.g.
`$ railroady -a --show-belongs_to -M | dot -Tpng > full_models.png`

We can also add new related tasks to railroady.rake.