### PR TITLE
Use sql_type to show string lengths and other database oddities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.sw?
 .DS_Store
 coverage

--- a/lib/railroady/models_diagram.rb
+++ b/lib/railroady/models_diagram.rb
@@ -108,7 +108,7 @@ class ModelsDiagram < AppDiagram
 
       content_columns.each do |a|
         content_column = a.name
-        content_column += ' :' + a.type.to_s unless @options.hide_types
+        content_column += ' :' + a.sql_type.to_s unless @options.hide_types
         node_attribs << content_column
       end
     end


### PR DESCRIPTION
Given that the model is an ActiveModel it might be useful to know string lengths as well. With sql_type you always know the ruby type, but not vice versa.