### PR TITLE
Fixing changes to AASM API

### DIFF
--- a/lib/railroady/aasm_diagram.rb
+++ b/lib/railroady/aasm_diagram.rb
@@ -53,7 +53,7 @@ class AasmDiagram < AppDiagram
 
     # Only interested in acts_as_state_machine models.
     process_acts_as_state_machine_class(current_class)  if current_class.respond_to?(:states)
-    process_aasm_class(current_class)  if current_class.respond_to?(:aasm_states)
+    process_aasm_class(current_class)  if current_class.respond_to?(:aasm_states) || current_class.respond_to?(:aasm)
   end # process_class
 
   def process_acts_as_state_machine_class(current_class)
@@ -91,13 +91,13 @@ class AasmDiagram < AppDiagram
     end
     @graph.add_node [node_type, current_class.name, node_attribs]
 
-    current_class.aasm.events.each do |event_name, event|
+    current_class.aasm.events.each do |event|
       event.transitions.each do |transition|
         @graph.add_edge [
           'event',
           current_class.name.downcase + '_' + transition.from.to_s,
           current_class.name.downcase + '_' + transition.to.to_s,
-          event_name.to_s
+          event.name.to_s
         ]
       end
     end


### PR DESCRIPTION
AASM version 4 has removed methods prefixed with aasm_ and has put them
under the aasm object.
(https://github.com/aasm/aasm/commit/e9a7686b3e1b837f2ce0d591e6d8789f6c4
26f36)

Additionally the events are now stored as an array and not a hash, so
the events loop has been refactored to read the name from the event
rather then the key value pair.