### PR TITLE
Consider not every models subdirectory to be a class namespace

### DIFF
--- a/lib/railroady/models_diagram.rb
+++ b/lib/railroady/models_diagram.rb
@@ -39,9 +39,31 @@ class ModelsDiagram < AppDiagram
   def engine_files
     engines.collect { |engine| Dir.glob("#{engine.root}/app/models/**/*.rb") }.flatten
   end
-
+  
   def extract_class_name(filename)
-    filename.match(/.*\/models\/(.*).rb$/)[1].camelize
+    filename_was, class_name = filename, nil
+      
+    filename = "app/models/#{filename.split('app/models')[1]}"   
+      
+    while filename.split('/').length > 2
+      begin
+        class_name = filename.match(/.*\/models\/(.*).rb$/)[1].camelize
+        class_name.constantize
+        
+        break
+      rescue Exception => e
+        class_name = nil
+        filename_end = filename.split('/')[2..-1]
+        filename_end.shift
+        filename = "#{filename.split('/')[0, 2].join('/')}/#{filename_end.join('/')}"
+      end
+    end
+    
+    if class_name.nil?
+      filename_was.match(/.*\/models\/(.*).rb$/)[1].camelize
+    else
+      class_name
+    end
   end
 
   # Process a model class

--- a/test/file_fixture/app/models/concerns/author_settings.rb
+++ b/test/file_fixture/app/models/concerns/author_settings.rb
@@ -1,0 +1,12 @@
+module AuthorSettings   
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :set_up_author
+  end
+
+  def set_up_author
+    self.created_by = 'Admin'
+    self.updated_by = 'Admin'
+  end
+end

--- a/test/lib/railroady/aasm_diagram_spec.rb
+++ b/test/lib/railroady/aasm_diagram_spec.rb
@@ -12,7 +12,7 @@ describe AasmDiagram do
       options = OptionsStruct.new(include_concerns: true)
       ad = AasmDiagram.new(options)
       files = ad.get_files('test/file_fixture/')
-      files.size.must_equal 4
+      files.size.must_equal 5
     end
 
     it 'should exclude a specific file' do

--- a/test/lib/railroady/models_diagram_spec.rb
+++ b/test/lib/railroady/models_diagram_spec.rb
@@ -12,7 +12,7 @@ describe ModelsDiagram do
       options = OptionsStruct.new(include_concerns: true)
       ad = ModelsDiagram.new(options)
       files = ad.get_files('test/file_fixture/')
-      files.size.must_equal 4
+      files.size.must_equal 5
     end
 
     it 'should exclude a specific file' do
@@ -57,6 +57,42 @@ describe ModelsDiagram do
       engines = [OpenStruct.new(root: 'test/file_fixture/lib')]
       md.stub(:engines, engines) do
         md.get_files.must_include('test/file_fixture/lib/app/models/dummy1.rb')
+      end
+    end
+  end
+  
+  describe '#extract_class_name' do
+    describe 'class can be found' do
+      describe 'module without namespace' do
+        module AuthorSettings
+        end
+        
+        it 'does not take every models subdirectory as a namespace' do
+          md = ModelsDiagram.new(OptionsStruct.new)
+          
+          md.extract_class_name('test/file_fixture/app/models/concerns/author_settings.rb').must_equal 'AuthorSettings'
+        end
+      end
+      
+      describe 'module with parent namespace / class' do
+        class User
+          module Authentication
+          end
+        end
+        
+        it 'does not take every models subdirectory as a namespace' do
+          md = ModelsDiagram.new(OptionsStruct.new)
+          
+          md.extract_class_name('test/file_fixture/app/models/concerns/user/authentication.rb').must_equal 'User::Authentication'
+        end
+      end
+    end
+    
+    describe 'class cannot be found' do
+      it 'returns the full class name' do
+        md = ModelsDiagram.new(OptionsStruct.new)
+        
+        md.extract_class_name('test/file_fixture/app/models/concerns/dummy.rb').must_equal 'Concerns::Dummy'
       end
     end
   end


### PR DESCRIPTION
This is the fix for https://github.com/preston/railroady/issues/62.

Maybe the same can be implemented for controllers.