### PR TITLE
Hide inherited fields in rails model diagrams

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -79,6 +79,9 @@ Models diagram options:
         --hide-magic                 Hide magic field names
         --hide-types                 Hide attributes type
         --hide-through               Hide through associations
+        --show-only-accessible-attributes
+                                     Show only columns which are accessible attributes
+        --hide-inherited-attributes  Hide attributes defined in superclasses (use with --show-only-accessible-attributes)
     -j, --join                       Concentrate edges
     -m, --modules                    Include modules
     -p, --plugins-models             Include plugins models

--- a/lib/railroady/models_diagram.rb
+++ b/lib/railroady/models_diagram.rb
@@ -127,6 +127,21 @@ class ModelsDiagram < AppDiagram
       else
         content_columns = current_class.columns
       end
+      
+      if @options.show_only_accessible_attributes
+        # pre-filter with accessible_attributes
+        aa_set = Set.new(current_class.accessible_attributes)
+        content_columns = content_columns.select { |c| aa_set.include?(c.name) } 
+
+        if @options.hide_inherited_attributes 
+          sc = current_class.superclass
+          while sc!=nil && sc != ActiveRecord::Base
+            sc_aa_set = Set.new(sc.accessible_attributes)
+            content_columns = content_columns.select { |c| !sc_aa_set.include?(c.name) } 
+            sc = sc.superclass
+          end
+        end
+      end
 
       content_columns.each do |a|
         content_column = a.name

--- a/lib/railroady/options_struct.rb
+++ b/lib/railroady/options_struct.rb
@@ -25,6 +25,8 @@ class OptionsStruct < OpenStruct
                      hide_public: false,
                      hide_protected: false,
                      hide_private: false,
+                     show_only_accessible_attributes: false,
+                     hide_inherited_attributes: false,
                      plugins_models: false,
                      engine_models: false,
                      engine_controllers: false,
@@ -101,6 +103,12 @@ class OptionsStruct < OpenStruct
       end
       opts.on('--hide-types', 'Hide attributes type') do |h|
         self.hide_types = h
+      end
+      opts.on('--show-only-accessible-attributes', 'Show only columns which are accessible attributes') do |h|
+        self.show_only_accessible_attributes = h
+      end
+      opts.on('--hide-inherited-attributes', 'Hide attributes defined in superclasses (use with --show-only-accessible-attributes)') do |h|
+        self.hide_inherited_attributes = h
       end
       opts.on('-j', '--join', 'Concentrate edges') do |j|
         self.join = j


### PR DESCRIPTION
@preston For a Rails project which uses Single Table Inheritance, I wanted to get rid of the superclasses' fields in subclasses in model diagrams. The only approach, which worked for me so far, was to look at the accessible attributes. 

So if the option `--show-only-accessible-attributes` is set, the `columns` are filtered for the entries which are in `current_class.accessible_attributes`. A second option `--hide-inherited-attributes` removes all entries which are in the `accessible_attributes` of superclasses (until `ActiveRecord::Base`).

Can you take a look whether this sounds good enough to merge?

Thanks - Rainer