### PR TITLE
Fix model diagram to not show ActiveRecord::Base as an inherited object

### DIFF
--- a/lib/railroady/models_diagram.rb
+++ b/lib/railroady/models_diagram.rb
@@ -92,8 +92,8 @@ class ModelsDiagram < AppDiagram
 
   def include_inheritance?(current_class)
     STDERR.puts current_class.superclass if @options.verbose
-    (defined?(ActiveRecord::Base) && current_class.superclass != ActiveRecord::Base) ||
-      (defined?(CouchRest::Model::Base) && current_class.superclass != CouchRest::Model::Base) ||
+    (defined?(ActiveRecord::Base) ? current_class.superclass != ActiveRecord::Base : true) &&
+      (defined?(CouchRest::Model::Base) ? current_class.superclass != CouchRest::Model::Base : true) &&
       (current_class.superclass != Object)
   end
 

--- a/test/lib/railroady/models_diagram_spec.rb
+++ b/test/lib/railroady/models_diagram_spec.rb
@@ -96,4 +96,67 @@ describe ModelsDiagram do
       end
     end
   end
+
+  describe '#include_inheritance?' do
+    after do
+      Object.send(:remove_const, :Child)
+    end
+    describe 'when class inherits from another app class' do
+      before do
+        class Parent; end;
+        class Child < Parent; end;
+      end
+      it 'returns true' do
+        md = ModelsDiagram.new(OptionsStruct.new)
+        md.include_inheritance?(Child).must_equal true
+      end
+      after do
+        Object.send(:remove_const, :Parent)
+      end
+    end
+
+    describe 'when class inherits from Object' do
+      before do
+        class Child < Object; end;
+      end
+      it 'returns false' do
+        md = ModelsDiagram.new(OptionsStruct.new)
+        md.include_inheritance?(Child).must_equal false
+      end
+    end
+
+    describe 'when class inherits from ActiveRecord::Base' do
+      before do
+        module ActiveRecord
+          class Base; end;
+        end
+        class Child < ActiveRecord::Base; end;
+      end
+      it 'returns false' do
+        md = ModelsDiagram.new(OptionsStruct.new)
+        md.include_inheritance?(Child).must_equal false
+      end
+      after do
+        Object.send(:remove_const, :ActiveRecord)
+      end
+    end
+
+    describe 'when class inherits from CouchRest::Model::Base' do
+      before do
+        module CouchRest
+          module Model
+            class Base; end;
+          end
+        end
+        class Child < CouchRest::Model::Base; end;
+      end
+      it 'returns false' do
+        md = ModelsDiagram.new(OptionsStruct.new)
+        md.include_inheritance?(Child).must_equal false
+      end
+      after do
+        Object.send(:remove_const, :CouchRest)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When generating model diagrams with inheritance on, ActiveRecord::Base was being displayed on the diagram. The original code looks like it is trying to filter out ActiveRecord::Base but in the course of development maybe it got broken. This PR fixes this so ActiveRecord::Base is filtered out during inheritance generation.

Also this will assist with https://github.com/preston/railroady/issues/90

If this wasn't the desired behaviour that ActiveRecord::Base and CouchRest::Model::Base be excluded then this PR can be ignored. Those desiring equivalent functionality could look at implementing a list of classes (not files) that would be excluded during generation.