### PR TITLE
adds support to skip classes in model diagrams.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,14 @@ Alternatively, you may run the 'railroady' command-line program at the Rails app
           	--all-columns                Show all columns (not just content columns)
           	--hide-magic                 Hide magic field names
           	--hide-types                 Hide attributes type
+        --excluded_classes class1[,classN] Exclude given classes (helpful when you can't reference a file, for example with PaperTrail::Version or other gems)
       	-j, --join                       Concentrate edges
       	-m, --modules                    Include modules
       	-p, --plugins-models             Include plugins models
       	-z, --engine-models              Include engine models
           	--include-concerns           Include models in concerns subdirectory
       	-t, --transitive                 Include transitive associations
-                                       	(through inheritance)
+                                       	(through inheritance)                                
 
   	Controllers diagram options:
           	--hide-public                Hide public methods

--- a/lib/railroady/models_diagram.rb
+++ b/lib/railroady/models_diagram.rb
@@ -285,6 +285,9 @@ class ModelsDiagram < AppDiagram
     assoc_class_name = assoc.class_name rescue nil
     assoc_class_name ||= assoc.name.to_s.underscore.singularize.camelize
 
+    # hide skipped classes
+    return if @options.excluded_classes.include?(assoc_class_name)
+
     # Only non standard association names needs a label
 
     # from patch #12384

--- a/lib/railroady/options_struct.rb
+++ b/lib/railroady/options_struct.rb
@@ -15,6 +15,7 @@ class OptionsStruct < OpenStruct
                      brief: false,
                      specify: [],
                      exclude: [],
+                     excluded_classes: [],
                      inheritance: false,
                      join: false,
                      label: false,
@@ -56,6 +57,9 @@ class OptionsStruct < OpenStruct
       end
       opts.on('-e', '--exclude file1[,fileN]', Array, 'Exclude given files') do |list|
         self.exclude = list
+      end
+      opts.on('--excluded_classes class1[,classN]', Array, 'Exclude given classes') do |list|
+        self.excluded_classes = list
       end
       opts.on('-i', '--inheritance', 'Include inheritance relations') do |i|
         self.inheritance = i

--- a/test/lib/railroady/models_diagram_spec.rb
+++ b/test/lib/railroady/models_diagram_spec.rb
@@ -60,42 +60,66 @@ describe ModelsDiagram do
       end
     end
   end
-  
+
   describe '#extract_class_name' do
     describe 'class can be found' do
       describe 'module without namespace' do
         module AuthorSettings
         end
-        
+
         it 'does not take every models subdirectory as a namespace' do
           md = ModelsDiagram.new(OptionsStruct.new)
-          
+
           md.extract_class_name('test/file_fixture/app/models/concerns/author_settings.rb').must_equal 'AuthorSettings'
         end
       end
-      
+
       describe 'module with parent namespace / class' do
         class User
           module Authentication
           end
         end
-        
+
         it 'does not take every models subdirectory as a namespace' do
           md = ModelsDiagram.new(OptionsStruct.new)
-          
+
           md.extract_class_name('test/file_fixture/app/models/concerns/user/authentication.rb').must_equal 'User::Authentication'
         end
       end
     end
-    
+
     describe 'class cannot be found' do
       it 'returns the full class name' do
         md = ModelsDiagram.new(OptionsStruct.new)
-        
+
         md.extract_class_name('test/file_fixture/app/models/concerns/dummy.rb').must_equal 'Concerns::Dummy'
       end
     end
   end
+
+describe '#process_association' do
+  after do
+    Object.send(:remove_const, :Child)
+  end
+  before do
+    module ActiveRecord
+      class Base; end;
+    end
+    class Child < ActiveRecord::Base;
+      def self.macro
+        ''
+      end
+      def self.options
+        []
+      end
+    end;
+  end
+  it 'should exclude a specific class' do
+    options = OptionsStruct.new(excluded_classes: ['Child'])
+    md = ModelsDiagram.new(options)
+    md.process_association('fake', Child).must_equal nil
+  end
+end
 
   describe '#include_inheritance?' do
     after do


### PR DESCRIPTION
This should be a problem for controllers, but for models sometimes there are dynamically generated model associations and there is no way to exclude via a file name. The papertrail gem and it's associated versions table and PaperTrail::Version model being a great example. It is on nearly every model we have so it really clutters up model diagrams and excluding it wasn't currently possible.

I currently monkey patched this feature into our rails app, but thought it might makes for a useful feature for other folks. 