### PR TITLE
Fix AASM diagrams with namespaced classes

### DIFF
--- a/lib/railroady/aasm_diagram.rb
+++ b/lib/railroady/aasm_diagram.rb
@@ -52,43 +52,19 @@ class AasmDiagram < AppDiagram
   def process_class(current_class)
     $stderr.print "\tProcessing #{current_class}\n" if @options.verbose
 
-    # Only interested in acts_as_state_machine models.
-    process_acts_as_state_machine_class(current_class)  if current_class.respond_to?(:states)
+    # Only interested in aasm models.
     process_aasm_class(current_class)  if current_class.respond_to?(:aasm_states) || current_class.respond_to?(:aasm)
-  end
-
-  def process_acts_as_state_machine_class(current_class)
-    node_attribs = []
-    node_type = 'aasm'
-
-    $stderr.print "\t\tprocessing as acts_as_state_machine\n" if @options.verbose
-    current_class.aasm.states.each do |state_name|
-      node_shape = current_class.aasm.initial_state == state_name ? ', peripheries = 2' : ''
-      node_attribs << "#{current_class.name.downcase}_#{state_name} [label=#{state_name} #{node_shape}];"
-    end
-    @graph.add_node [node_type, current_class.name, node_attribs]
-
-    current_class.aasm.events.each do |event|
-      event_name = event.name
-      event.transitions.each do |transition|
-        @graph.add_edge [
-          'event',
-          "#{current_class.name.downcase}_#{transition.from}",
-          "#{current_class.name.downcase}_#{transition.to}",
-          event_name.to_s
-        ]
-      end
-    end
   end
 
   def process_aasm_class(current_class)
     node_attribs = []
     node_type = 'aasm'
+    diagram_friendly_class_name = current_class.name.downcase.gsub(/[^a-z0-9\-_]+/i, '_')
 
     $stderr.print "\t\tprocessing as aasm\n" if @options.verbose
     current_class.aasm.states.each do |state|
       node_shape = current_class.aasm.initial_state == state.name ? ', peripheries = 2' : ''
-      node_attribs << "#{current_class.name.downcase}_#{state.name} [label=#{state.name} #{node_shape}];"
+      node_attribs << "#{diagram_friendly_class_name}_#{state.name} [label=#{state.name} #{node_shape}];"
     end
     @graph.add_node [node_type, current_class.name, node_attribs]
 
@@ -96,8 +72,8 @@ class AasmDiagram < AppDiagram
       event.transitions.each do |transition|
         @graph.add_edge [
           'event',
-          "#{current_class.name.downcase}_#{transition.from}",
-          "#{current_class.name.downcase}_#{transition.to}",
+          "#{diagram_friendly_class_name}_#{transition.from}",
+          "#{diagram_friendly_class_name}_#{transition.to}",
           event.name.to_s
         ]
       end

--- a/lib/railroady/diagram_graph.rb
+++ b/lib/railroady/diagram_graph.rb
@@ -96,7 +96,7 @@ class DiagramGraph
       options = "shape=box, style=dotted, label=\"#{name}\""
     when 'aasm'
       # Return subgraph format
-      return "subgraph cluster_#{name.downcase} {\n\tlabel = #{quote(name)}\n\t#{attributes.join("\n  ")}}"
+      return "subgraph cluster_#{name.downcase.gsub(/[^a-z0-9\-_]+/i, '_')} {\n\tlabel = #{quote(name)}\n\t#{attributes.join("\n  ")}}"
     end
     options = [options, custom_options].compact.reject(&:empty?).join(', ')
     "\t#{quote(name)} [#{options}]\n"


### PR DESCRIPTION
Before:
```
railroady -A | dot -Tsvg > doc/arch/state_machines.svg
Error: <stdin>: syntax error in line 11 near ':'
```
Invalid output:
```
subgraph cluster_applets::onetimeevent {
	label = "Applets::OneTimeEvent"
	applets::onetimeevent_pending [label=pending , peripheries = 2];
  applets::onetimeevent_active [label=active ];
  applets::onetimeevent_disabled [label=disabled ];}
```
Valid output:
```
subgraph cluster_applets_onetimeevent {
	label = "Applets::OneTimeEvent"
	applets_onetimeevent_pending [label=pending , peripheries = 2];
  applets_onetimeevent_active [label=active ];
  applets_onetimeevent_disabled [label=disabled ];}
```
Code to fix this was cribbed from [ActiveSupport::Inflector#parameterize](https://github.com/rails/rails/blob/v5.1.5/activesupport/lib/active_support/inflector/transliterate.rb#L88)

I also removed support for `acts_as_state_machine` because that code didn't look like it would work (had references to `aasm` in it) and that gem hasn't been updated in eons.